### PR TITLE
client code has to support content-types with charset=utf-8

### DIFF
--- a/lib/client/api_client.js
+++ b/lib/client/api_client.js
@@ -5,7 +5,7 @@ define(function (require) {
 
   var knownMimes = [
     {
-      type: (/^application\/[a-z+\-]*hal\+json$/),
+      type: (/^application\/[a-z+\-]*hal\+json/),
       parse: function (data) {
         return new hal.Resource(data);
       }


### PR DESCRIPTION
api now replies with `application/***+hal+json; charset=utf-8`
